### PR TITLE
crates/squashfs: ignore exit code 2

### DIFF
--- a/crates/squashfs/src/lib.rs
+++ b/crates/squashfs/src/lib.rs
@@ -194,12 +194,13 @@ pub fn extract<P: AsRef<Path>, Q: AsRef<Path>, F: FnMut(i32)>(
     }
 
     let status = child.wait()?;
-    if status.success() {
-        Ok(())
-    } else {
-        Err(Error::new(
-            ErrorKind::Other,
-            format!("archive extraction failed with status: {}", status),
-        ))
+    match status.code() {
+        Some(0) | Some(2) => Ok(()),
+        _ => {
+            Err(Error::new(
+                ErrorKind::Other,
+                format!("archive extraction failed with status: {}", status),
+            ))
+        }
     }
 }


### PR DESCRIPTION
`unsquashfs` returns exit code 2 on non-fatal errors, as mentioned by the manpage:

> 2       Non-fatal errors occurred, e.g. no support for XATTRs, Symbolic links in output filesystem or couldn't write permissions to output filesystem. Unsquashfs continued and did not abort.

When reusing partitions, extracting the filesystem squashfs causes symlinks to be created (which doesn't happen when creating partitions from scratch), thus failing to proceed with the installation due to exit code 2.

We can safely ignore such error, so this PR replaces the handling of `unsquashfs`' exit code to return `Ok(())` on either exit code 0 or 2.