### PR TITLE
Add support for bios_grub partition flag

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -546,6 +546,7 @@ fn parse_flags(flags: &str) -> Vec<PartitionFlag> {
             "legacy_boot" => Some(PartitionFlag::PED_PARTITION_LEGACY_BOOT),
             "msft_data" => Some(PartitionFlag::PED_PARTITION_MSFT_DATA),
             "irst" => Some(PartitionFlag::PED_PARTITION_IRST),
+            "bios_grub" => Some(PartitionFlag::PED_PARTITION_BIOS_GRUB),
             _ => None,
         })
         .collect::<Vec<_>>()


### PR DESCRIPTION
Distinst doesn't support `bios_grub`, which is a flag required to setup boot partitions in GTP filesystems when in BIOS mode. This commit adds support for such flag.